### PR TITLE
Fix non-SSL connections with logging disabled

### DIFF
--- a/adafruit_minimqtt/adafruit_minimqtt.py
+++ b/adafruit_minimqtt/adafruit_minimqtt.py
@@ -227,14 +227,15 @@ class MQTT:
                 "ssl_context must be set before using adafruit_mqtt for secure MQTT."
             )
 
-        if self.logger and port == MQTT_TLS_PORT:
-            self.logger.info(
-                "Establishing a SECURE SSL connection to {0}:{1}".format(host, port)
-            )
-        else:
-            self.logger.info(
-                "Establishing an INSECURE connection to {0}:{1}".format(host, port)
-            )
+        if self.logger:
+            if port == MQTT_TLS_PORT:
+                self.logger.info(
+                    "Establishing a SECURE SSL connection to {0}:{1}".format(host, port)
+                )
+            else:
+                self.logger.info(
+                    "Establishing an INSECURE connection to {0}:{1}".format(host, port)
+                )
 
         addr_info = self._socket_pool.getaddrinfo(
             host, port, 0, self._socket_pool.SOCK_STREAM


### PR DESCRIPTION
The change in PR #71 introduced a regression where it was not possible to start an insecure connection without logging enabled. I've just moved the logging under a single if block